### PR TITLE
merge v1.1.0 - upgrade dependencies and fix security leaks

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,62 @@
+{
+  "branch": "next",
+  "repositoryUrl": "https://github.com/viewar/viewar-boilerplate-vanilla.git",
+  "plugins": [
+   [
+    "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": [
+            "BREAKING CHANGE",
+            "BREAKING CHANGES",
+            "BREAKING"
+          ]
+        },
+        "writerOpts": {
+          "commitsSort": [
+            "subject",
+            "scope"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n> generated with [@semantic-release/changelog](https://github.com/semantic-release/changelog)"
+      }
+    ],
+    ["@semantic-release/npm", {
+      "npmPublish": false,
+      "tarballDir": "releases",
+    }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "package.json"
+        ],
+        "message": "chore(release): 🤖🔖🚀 v${nextRelease.version} \n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github"
+    ]
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,14 @@ install: npm install
 script:
   - npm run format
   - npm run build
+
+before_deploy:
+  - npm i -g semantic-release
+  - npm i -g @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/npm @semantic-release/git @semantic-release/github
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: npx semantic-release
+  on:
+    branch: next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+> generated with [@semantic-release/changelog](https://github.com/semantic-release/changelog)
+
+# [1.1.0](https://github.com/viewar/viewar-boilerplate-vanilla/compare/v1.0.2...v1.1.0) (2019-10-19)
+
+
+### Bug Fixes
+
+* update node sass to fix gyp postinstall ([8b3af7a](https://github.com/viewar/viewar-boilerplate-vanilla/commit/8b3af7a2af773dab5e2fbdde29ed7fbb9aa231be))
+
+
+### Features
+
+* add semantic-release on branch "next" ([#13](https://github.com/viewar/viewar-boilerplate-vanilla/issues/13)) ([d445d41](https://github.com/viewar/viewar-boilerplate-vanilla/commit/d445d414ac6486efbc17b635b0065dc1209d1fb2))

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 [![Build Status](https://travis-ci.com/viewar/viewar-boilerplate-vanilla.svg?&branch=master)](https://travis-ci.com/viewar/viewar-boilerplate-vanilla) 
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=viewar/viewar-boilerplate-vanilla)](https://dependabot.com) 
 [![PRs Welcome][pr-welcome]](http://makeapullrequest.com) 
-[![Conventional Commits](https://img.shields.io/badge/✔-Conventional%20Commits-blue.svg)](https://conventionalcommits.org)
+[![Conventional Commits](https://img.shields.io/badge/✔-Conventional%20Commits-blue.svg)](https://conventionalcommits.org) 
+[![Semantic Versioning][semantic-img]][semantic-url]
 
 [pr-welcome]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg
+[semantic-img]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-blue.svg
+[semantic-url]: https://semver.org/
 
 This sample project demonstrates a basic usage of the [ViewAR Api](https://www.npmjs.com/package/viewar-api) using pure JavaScript without any framework.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8339,13 +8339,43 @@
       }
     },
     "style-loader": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
-      "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
+      "integrity": "sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0"
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.5.0.tgz",
+          "integrity": "sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viewar-boilerplate",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Boilerplate app for ViewAR SDK",
   "main": "index.js",
   "repository": "https://github.com/viewar/viewar-boilerplate-react.git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Boilerplate app for ViewAR SDK",
   "main": "index.js",
+  "repository": "https://github.com/viewar/viewar-boilerplate-react.git",
   "scripts": {
     "clean": "rimraf build && rimraf bundle",
     "deploy": "viewar-cli deploy",
@@ -39,7 +40,7 @@
     "prettier": "^1.15.3",
     "rimraf": "^2.6.3",
     "sass-loader": "^7.1.0",
-    "style-loader": "^0.23.1",
+    "style-loader": "^1.0.0",
     "webpack": "^4.28.3",
     "webpack-cli": "^3.2.0",
     "webpack-dev-server": "^3.1.14",


### PR DESCRIPTION
* feat(CI): add TravisCI config and badges
* feat: add semantic-release on branch "next" (#13)
* fix: update node sass to fix gyp postinstall
* chore(npm): set version to v1.0.2
* fix(dep-security): Bump lodash from 4.17.11 to 4.17.15 (#2)
* fix(dep-security): Bump lodash.template from 4.4.0 to 4.5.0 (#6)
* Bump mixin-deep from 1.3.1 to 1.3.2 (#8)
* Bump postcss from 7.0.14 to 7.0.18 (#10)
* Bump postcss-preset-env from 6.5.0 to 6.7.0 (#7)
* Bump copy-webpack-plugin from 4.6.0 to 5.0.4 (#5)
* Bump viewar-api from 0.30.3 to 0.56.1 (#3)
* Bump viewar-core from 11.18.1 to 11.41.1 (#9)
* Bump viewar-core from 11.18.1 to 11.41.1
* Bump style-loader from 0.23.1 to 1.0.0 (#1)
* docs(README): add bade for semantic-release
